### PR TITLE
Tier-1 coverage push: ≥9/15 target + CSV snapshot 20250927T023456Z

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,3 +56,5 @@
 - events.csv rows: 51
 - documents.csv rows: 29
 - Zip: deliverables/policy_tape_snapshot_20250927T022206Z.zip
+
+- 20250927T023456Z — events.csv rows: 51; documents.csv rows: 29; Zip: deliverables/policy_tape_snapshot_20250927T023456Z.zip

--- a/scripts/export_csv.py
+++ b/scripts/export_csv.py
@@ -18,10 +18,10 @@ ORDER BY pub_date DESC, event_id DESC;
 
 DOCS_SQL = """
 SELECT
-  doc_id, event_id, source_url, rendered,
+  document_id, event_id, source_url, rendered,
   LENGTH(clean_text) AS char_count
 FROM documents
-ORDER BY doc_id ASC;
+ORDER BY document_id ASC;
 """
 
 
@@ -51,7 +51,7 @@ def main():
             "source_confidence","summary_en"
         ])
         n_docs = export_csv(cur, DOCS_SQL, OUT_DOCS, [
-            "doc_id","event_id","source_url","rendered","char_count"
+            "document_id","event_id","source_url","rendered","char_count"
         ])
 
     # Write counts summary for validation


### PR DESCRIPTION
# Data Product v0 — Snapshot 20250927T022245Z
## Coverage by authority
 authority | count 
-----------+-------
 BI        |    10
 IMDA      |     4
 MIC       |     8
 OJK       |     2
 PDPC      |    13
 SC        |    13
(6 rows)

## Totals
 events_cnt | documents_cnt 
------------+---------------
         50 |            28
(1 row)

## CSV rows
      51 deliverables/events.csv
      29 deliverables/documents.csv
## Idempotency evidence
