### PR TITLE
Firecrawl-first ingest + proofs + CSV snapshot 20250928T044533Z

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -39,7 +39,9 @@ specialist:
 
 
 regional_gov:
-  - { name: "MAS (Singapore) News", url: "https://www.mas.gov.sg/news", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "MAS (Singapore) News", url: "https://www.mas.gov.sg/news/media-releases", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "MAS (Singapore) Speeches", url: "https://www.mas.gov.sg/news/speeches", category: "Official Data", max_depth: 1, limit: 10 }
+
   - { name: "IMDA (Singapore) Press", url: "https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches", category: "Official Data", max_depth: 1, limit: 10 }
 
   - { name: "BOT (Thailand) News", url: "https://www.bot.or.th/en/news-and-media/press-release", category: "Official Data", max_depth: 1, limit: 10 }

--- a/configs/firecrawl_seed.json
+++ b/configs/firecrawl_seed.json
@@ -7,21 +7,23 @@
   },
   "denySelectors": ["header", "nav", "footer", ".breadcrumb", ".share", ".social", ".related", ".tags"],
   "startUrls": [
-    {"url": "https://www.mas.gov.sg/news", "label": "MAS"},
+    {"url": "https://www.mas.gov.sg/news/media-releases", "label": "MAS", "render": true},
+    {"url": "https://www.mas.gov.sg/news/speeches", "label": "MAS", "render": true},
+
     {"url": "https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches", "label": "IMDA"},
-    {"url": "https://asean.org/category/news/", "label": "ASEAN"},
-    {"url": "https://www.pdpc.gov.sg/News-and-Events", "label": "PDPC"},
-    {"url": "https://www.bi.go.id/id/publikasi/ruang-media/news-release/", "label": "BI"},
-    {"url": "https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers", "label": "OJK"},
+    {"url": "https://asean.org/category/news/", "label": "ASEAN", "render": true},
+    {"url": "https://www.pdpc.gov.sg/News-and-Events", "label": "PDPC", "render": false},
+    {"url": "https://www.bi.go.id/id/publikasi/ruang-media/news-release/", "label": "BI", "render": false},
+    {"url": "https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers", "label": "OJK", "render": false},
     {"url": "https://kominfo.go.id/siaran-pers", "label": "KOMINFO"},
-    {"url": "https://www.bot.or.th/en/news-and-media/press-release", "label": "BOT"},
-    {"url": "https://www.bnm.gov.my/press-release", "label": "BNM"},
-    {"url": "https://www.sc.com.my/resources/media/media-release", "label": "SC"},
-    {"url": "https://www.mcmc.gov.my/media/media-releases", "label": "MCMC"},
-    {"url": "https://www.bsp.gov.ph/SitePages/Media%20and%20Research/MediaReleases.aspx", "label": "BSP"},
-    {"url": "https://dict.gov.ph/category/press-releases/", "label": "DICT"},
+    {"url": "https://www.bot.or.th/en/news-and-media/press-release", "label": "BOT", "render": true},
+    {"url": "https://www.bnm.gov.my/press-release", "label": "BNM", "render": true},
+    {"url": "https://www.sc.com.my/resources/media/media-release", "label": "SC", "render": false},
+    {"url": "https://www.mcmc.gov.my/media/media-releases", "label": "MCMC", "render": true},
+    {"url": "https://www.bsp.gov.ph/SitePages/Media%20and%20Research/MediaReleases.aspx", "label": "BSP", "render": true},
+    {"url": "https://dict.gov.ph/category/press-releases/", "label": "DICT", "render": true},
     {"url": "https://english.mic.gov.vn/Pages/TinTuc/tintuckinhte.aspx", "label": "MIC"},
-    {"url": "https://www.sbv.gov.vn/webcenter/portal/en/home/sbv/news/press-release", "label": "SBV"}
+    {"url": "https://www.sbv.gov.vn/webcenter/portal/en/home/sbv/news/press-release", "label": "SBV", "render": true}
   ]
 }
 

--- a/docs/FEEDS.md
+++ b/docs/FEEDS.md
@@ -1,0 +1,32 @@
+## FEEDS: Discovery & Fetch Methods (MVP)
+
+- Primary fetch policy: Firecrawl-first with HTTP fallback
+- Rendering: Global render=true; selective render=false for fast HTML authorities (PDPC, SC, OJK, BI)
+- Limits: discover_links=8, process_per_source=5, delay≈1200ms, redirects≤5
+- Seeds are authoritative in configs/firecrawl_seed.json (mirrored in config/sources.yaml)
+
+### Authorities and Methods
+
+Authority | Seed URL | Primary | Render Override
+---|---|---|---
+ASEAN | https://asean.org/category/news/ | Firecrawl | render=true
+MAS (Media Releases) | https://www.mas.gov.sg/news/media-releases | Firecrawl | render=true
+MAS (Speeches) | https://www.mas.gov.sg/news/speeches | Firecrawl | render=true
+IMDA | https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches | Firecrawl | render=true
+PDPC | https://www.pdpc.gov.sg/News-and-Events | HTTP/Firecrawl | render=false
+BI | https://www.bi.go.id/id/publikasi/ruang-media/news-release/ | HTTP/Firecrawl | render=false
+OJK | https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers | HTTP/Firecrawl | render=false
+KOMINFO | https://kominfo.go.id/siaran-pers | Firecrawl | render=true
+BOT | https://www.bot.or.th/en/news-and-media/press-release | Firecrawl | render=true
+BNM | https://www.bnm.gov.my/press-release | Firecrawl | render=true
+SC | https://www.sc.com.my/resources/media/media-release | HTTP/Firecrawl | render=false
+MCMC | https://www.mcmc.gov.my/media/media-releases | Firecrawl | render=true
+BSP | https://www.bsp.gov.ph/SitePages/Media%20and%20Research/MediaReleases.aspx | Firecrawl | render=true
+DICT | https://dict.gov.ph/category/press-releases/ | Firecrawl | render=true
+MIC | https://english.mic.gov.vn/Pages/TinTuc/tintuckinhte.aspx | Firecrawl | render=true
+SBV | https://www.sbv.gov.vn/webcenter/portal/en/home/sbv/news/press-release | Firecrawl | render=true
+
+Notes
+- Documented-only entries that are temporarily blocked remain included for link discovery; we only ingest pages returning HTTP 200.
+- No secrets in logs; use env $(grep -Ev '^#|^$' app/.env | xargs) pattern for runs.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,3 +58,4 @@
 - Zip: deliverables/policy_tape_snapshot_20250927T022206Z.zip
 
 - 20250927T023456Z — events.csv rows: 51; documents.csv rows: 29; Zip: deliverables/policy_tape_snapshot_20250927T023456Z.zip
+- 20250928T044533Z: events=50, documents=28, zip=deliverables/policy_tape_snapshot_20250928T044533Z.zip (Firecrawl-first)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2,7 +2,7 @@
 
 ### Scope
 - Tier‑1 authority ingestion only (15 authorities)
-- Rendering via Firecrawl when available; otherwise direct urllib
+- Firecrawl-first with HTTP fallback; global render=true with selective render=false overrides (PDPC, SC, OJK, BI)
 - Storage: Neon Postgres (events, documents) with pgvector
 - No OCR/cloud features beyond OpenAI + Firecrawl
 
@@ -59,13 +59,13 @@ Authority | URL | render_required | selectors
 ASEAN | https://asean.org/category/news/ | true | -
 MAS | https://www.mas.gov.sg/news | true | article .article-content, .article-content
 IMDA | https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches | true | .rich-text, .content
-PDPC | https://www.pdpc.gov.sg/News-and-Events | true | -
-BI | https://www.bi.go.id/id/publikasi/ruang-media/news-release/ | true | -
-OJK | https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers | true | -
+PDPC | https://www.pdpc.gov.sg/News-and-Events | false | -
+BI | https://www.bi.go.id/id/publikasi/ruang-media/news-release/ | false | -
+OJK | https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers | false | -
 KOMINFO | https://kominfo.go.id/siaran-pers | true | -
 BOT | https://www.bot.or.th/en/news-and-media/press-release | true | -
 BNM | https://www.bnm.gov.my/press-release | true | -
-SC | https://www.sc.com.my/resources/media/media-release | true | -
+SC | https://www.sc.com.my/resources/media/media-release | false | -
 MCMC | https://www.mcmc.gov.my/media/media-releases | true | -
 BSP | https://www.bsp.gov.ph/SitePages/Media%20and%20Research/MediaReleases.aspx | true | -
 DICT | https://dict.gov.ph/category/press-releases/ | true | -


### PR DESCRIPTION
Enforce Firecrawl-first (global render=true), HTTP fallback, per-authority render=false for PDPC/SC/OJK/BI. Dual-window ingestion, idempotency, DB proofs, CSV snapshot, SPEC/FEEDS/ROADMAP updated.
