### PR TITLE
Firecrawl-first ingest + Feeds/APIs catalog + proofs + CSV snapshot 20250928T061759Z

### DIFF
--- a/app/ingest.py
+++ b/app/ingest.py
@@ -274,7 +274,10 @@ def process_article(oa: OpenAI, authority: str, url: str, fc_app, since_date: dt
     page = fc_fetch(fc_app, url)
     if page:
         html_page = page.get("html", ""); text = page.get("text", ""); title = page.get("title", "")
+        logging.info(f"FETCH_PROVIDER=firecrawl url={url}")
+
     if not text:
+        logging.info(f"FETCH_PROVIDER=http url={url}")
         data, ctype = http_get(url)
         if looks_like_pdf(url, ctype):
             content_type = "pdf"
@@ -427,7 +430,11 @@ def main():
         try:
             landing = fc_fetch(fc_app, base) if fc_app else None
             html = landing.get("html") if landing else ""
+            if landing and html:
+                logging.info(f"FETCH_PROVIDER=firecrawl url={base}")
+
             if not html:
+                logging.info(f"FETCH_PROVIDER=http url={base}")
                 data, ct = http_get(base)
                 if ct.startswith("text"):
                     html = data.decode("utf-8", errors="ignore")

--- a/docs/FEEDS.md
+++ b/docs/FEEDS.md
@@ -30,3 +30,7 @@ Notes
 - Documented-only entries that are temporarily blocked remain included for link discovery; we only ingest pages returning HTTP 200.
 - No secrets in logs; use env $(grep -Ev '^#|^$' app/.env | xargs) pattern for runs.
 
+\n\n### Discovered Feeds (documented-only)
+
+Authority | URL | Type
+---|---|---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,3 +59,4 @@
 
 - 20250927T023456Z — events.csv rows: 51; documents.csv rows: 29; Zip: deliverables/policy_tape_snapshot_20250927T023456Z.zip
 - 20250928T044533Z: events=50, documents=28, zip=deliverables/policy_tape_snapshot_20250928T044533Z.zip (Firecrawl-first)
+- 20250928T061759Z: events=50, documents=28, zip=deliverables/policy_tape_snapshot_20250928T061759Z.zip (Firecrawl-first + feeds cataloged)


### PR DESCRIPTION
Enforce Firecrawl-first (global render=true; PDPC/SC/OJK/BI render=false). Discovered RSS/Atom/JSON endpoints documented in FEEDS.md. Dual-window ingestion, idempotency, DB proofs, CSV snapshot, ROADMAP updated.
