### PR TITLE
Tier-1 closeout: BNM+KOMINFO seeds + proofs + CSV snapshot

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -29,8 +29,8 @@ official_data:
   - { name: "IMF (News)", url: "https://www.imf.org/en/News", category: "Official Data", max_depth: 1, limit: 12 }
   - { name: "World Bank (East Asia & Pacific)", url: "https://www.worldbank.org/en/region/eap/publications", category: "Official Data", max_depth: 1, limit: 10 }
 
-  - { name: "ASEAN Secretariat (News)", url: "https://asean.org/category/news/", category: "Official Data", max_depth: 1, limit: 10 }
-  - { name: "ASEAN Secretariat (Announcements)", url: "https://asean.org/category/announcements/", category: "Official Data", max_depth: 1, limit: 8 }
+  - { name: "ASEAN Secretariat (Press Releases)", url: "https://asean.org/tag/press-release/", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "ASEAN Secretariat (News)", url: "https://asean.org/news/", category: "Official Data", max_depth: 1, limit: 8 }
 
 
 specialist:
@@ -49,7 +49,20 @@ regional_gov:
   - { name: "OJK (Indonesia) Press", url: "https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers", category: "Official Data", max_depth: 1, limit: 10 }
   - { name: "Bank Indonesia (BI) News Releases", url: "https://www.bi.go.id/id/publikasi/ruang-media/news-release/", category: "Official Data", max_depth: 1, limit: 10 }
 
-  - { name: "BOT (Thailand) Press", url: "https://www.bot.or.th/en/press/", category: "Official Data", max_depth: 1, limit: 8 }
+  - { name: "BOT (Thailand) News & Media", url: "https://www.bot.or.th/en/news-and-media.html", category: "Official Data", max_depth: 1, limit: 8 }
 
-  - { name: "BOT (Thailand) News", url: "https://www.bot.or.th/en/news-and-media/press-release", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "BOT (Thailand) News Listing", url: "https://www.bot.or.th/en/news-and-media/news.html", category: "Official Data", max_depth: 1, limit: 10 }
 
+  - { name: "PDPC (Singapore) Announcements", url: "https://www.pdpc.gov.sg/News-and-Events", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "SC (Malaysia) Media Releases", url: "https://www.sc.com.my/resources/media/media-release", category: "Official Data", max_depth: 1, limit: 10 }
+
+
+  - { name: "BNM (Malaysia) Press Releases", url: "https://www.bnm.gov.my/press-release", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "BNM (Malaysia) Sitemap", url: "https://www.bnm.gov.my/sitemap.xml", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "MCMC (Malaysia) Media Releases", url: "https://www.mcmc.gov.my/media/media-releases", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "BSP (Philippines) Media & Research", url: "https://www.bsp.gov.ph/SitePages/MediaAndResearch/MediaList.aspx", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "DICT (Philippines) Press Releases", url: "https://dict.gov.ph/category/press-releases/", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "MIC (Vietnam) News", url: "https://english.mic.gov.vn/Pages/TinTuc/tintuckinhte.aspx", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "SBV (Vietnam) English Portal", url: "https://sbv.gov.vn/en/", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "KOMINFO (Indonesia) Press", url: "https://kominfo.go.id/siaran-pers", category: "Official Data", max_depth: 1, limit: 10 }
+  - { name: "KOMINFO (Indonesia) Feed", url: "https://kominfo.go.id/feed", category: "Official Data", max_depth: 1, limit: 10 }

--- a/configs/firecrawl_seed.json
+++ b/configs/firecrawl_seed.json
@@ -29,7 +29,12 @@
     "OJK": {"proxy": "stealth", "pageOptions": {"waitFor": 5000}},
     "IMDA": {"proxy": "auto"},
     "MAS": {"proxy": "auto"},
-    "BI": {"proxy": "auto"}
+    "BI": {"proxy": "auto"},
+    "BNM": {"proxy": "stealth", "pageOptions": {"waitFor": 5000}},
+    "MCMC": {"proxy": "stealth", "pageOptions": {"waitFor": 5000}},
+    "DICT": {"proxy": "stealth", "pageOptions": {"waitFor": 5000}},
+    "BSP": {"proxy": "auto"},
+    "SBV": {"proxy": "auto"}
   },
   "aggressiveAuthorities": {
     "IMDA": {"stealthProxy": true, "timeout": 60000},
@@ -48,21 +53,23 @@
     {"url": "https://www.mas.gov.sg/news/speeches", "label": "MAS", "render": true},
 
     {"url": "https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches", "label": "IMDA", "render": true},
-    {"url": "https://asean.org/category/news/", "label": "ASEAN", "render": true},
-    {"url": "https://asean.org/category/announcements/", "label": "ASEAN", "render": true},
+    {"url": "https://asean.org/tag/press-release/", "label": "ASEAN", "render": true},
+    {"url": "https://asean.org/news/", "label": "ASEAN", "render": true},
     {"url": "https://www.pdpc.gov.sg/News-and-Events", "label": "PDPC", "render": false},
     {"url": "https://www.bi.go.id/id/publikasi/ruang-media/news-release/", "label": "BI", "render": true},
     {"url": "https://www.ojk.go.id/id/berita-dan-kegiatan/siaran-pers", "label": "OJK", "render": true},
     {"url": "https://kominfo.go.id/siaran-pers", "label": "KOMINFO", "render": true},
-    {"url": "https://www.bot.or.th/en/news-and-media/press-release", "label": "BOT", "render": true},
-    {"url": "https://www.bot.or.th/en/press/", "label": "BOT", "render": true},
+{"url": "https://kominfo.go.id/feed", "label": "KOMINFO", "render": true, "proxy": "stealth", "pageOptions": {"waitFor": 12000}},
+    {"url": "https://www.bot.or.th/en/news-and-media.html", "label": "BOT", "render": true},
+    {"url": "https://www.bot.or.th/en/news-and-media/news.html", "label": "BOT", "render": true},
     {"url": "https://www.bnm.gov.my/press-release", "label": "BNM", "render": true},
+{"url": "https://www.bnm.gov.my/sitemap.xml", "label": "BNM", "render": true, "proxy": "stealth", "pageOptions": {"waitFor": 12000}},
     {"url": "https://www.sc.com.my/resources/media/media-release", "label": "SC", "render": false},
     {"url": "https://www.mcmc.gov.my/media/media-releases", "label": "MCMC", "render": true},
-    {"url": "https://www.bsp.gov.ph/SitePages/Media%20and%20Research/MediaReleases.aspx", "label": "BSP", "render": true},
+    {"url": "https://www.bsp.gov.ph/SitePages/MediaAndResearch/MediaList.aspx", "label": "BSP", "render": true},
     {"url": "https://dict.gov.ph/category/press-releases/", "label": "DICT", "render": true},
     {"url": "https://english.mic.gov.vn/Pages/TinTuc/tintuckinhte.aspx", "label": "MIC", "render": true},
-    {"url": "https://www.sbv.gov.vn/webcenter/portal/en/home/sbv/news/press-release", "label": "SBV", "render": true}
+    {"url": "https://sbv.gov.vn/en/", "label": "SBV", "render": true}
   ]
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,3 +61,12 @@
 - 20250928T044533Z: events=50, documents=28, zip=deliverables/policy_tape_snapshot_20250928T044533Z.zip (Firecrawl-first)
 - 20250928T061759Z: events=50, documents=28, zip=deliverables/policy_tape_snapshot_20250928T061759Z.zip (Firecrawl-first + feeds cataloged)
 - 20250928T075201Z: events=72, documents=29, zip=deliverables/policy_tape_snapshot_20250928T075201Z.zip (Firecrawl-first unlock)
+- 20250929T110033Z: events=238, documents=96, zip=deliverables/policy_tape_snapshot_20250929T110033Z.zip (closeout)
+
+
+### Next Sprint — Canonical Backfill (Core Rulebook + 24–36m recents)
+- [ ] Canonical pages per authority (laws/acts, regs, notices, gazettes) — CSV seed committed
+- [ ] Backfill window (since 2019-01-01) executed with Firecrawl-first + PDF parsing
+- [ ] Version tags (revised/amended) stored
+- [ ] Export: deliverables/events.csv, deliverables/documents.csv + snapshot ZIP
+- [ ] Idempotency reruns & DB proofs attached


### PR DESCRIPTION
# Closeout Summary
- Coverage: 13/15 authorities (missing: BNM, KOMINFO). See db_auth_counts_closeout.txt; totals in db_totals_closeout.txt
- Idempotency: pass (items_new=0 on rerun). See idempotency_closeout.txt
- Provider/Quality telemetry: provider_events.csv, quality_drops.csv
- New snapshot: deliverables/policy_tape_snapshot_20250929T110033Z.zip

## Alt URL checks
URL: https://www.bnm.gov.my/press-release
HTTP/2 403 
server: CloudFront
date: Mon, 29 Sep 2025 09:03:13 GMT
content-type: text/html
content-length: 919

URL: https://www.bnm.gov.my/sitemap.xml
HTTP/2 403 
server: CloudFront
date: Mon, 29 Sep 2025 09:03:13 GMT
content-type: text/html
content-length: 919

URL: https://www.bnm.gov.my/press-release?year=2024
HTTP/2 403 
server: CloudFront
date: Mon, 29 Sep 2025 09:03:13 GMT
content-type: text/html
content-length: 919

URL: https://kominfo.go.id/siaran-pers

URL: https://kominfo.go.id/feed

URL: https://kominfo.go.id/sitemap.xml

GET_STATUS https://www.bnm.gov.my/press-release -> 403
GET_STATUS https://www.bnm.gov.my/sitemap.xml -> 403
GET_STATUS https://www.bnm.gov.my/press-release?year=2024 -> 403
GET_STATUS https://kominfo.go.id/siaran-pers -> 000
GET_STATUS https://kominfo.go.id/feed -> 000
GET_STATUS https://kominfo.go.id/sitemap.xml -> 000

## Provider attribution (evidence)
- provider_events.csv shows Firecrawl v2 as primary across Tier-1; BNM and KOMINFO attempts recorded with stealth + waitFor escalation (e.g., rows containing https://www.bnm.gov.my/press-release and https://kominfo.go.id/feed)
- fc_errors.csv excerpts include BNM/KOMINFO crawl_retry_error with pageOptions kwarg (compat note)

## Sample (BNM/KOMINFO)
authority	title	preview	url
(0 rows)

## Map+Batch attempt
See data/output/validation/latest/map_batch_closeout.log:
- BNM map from https://www.bnm.gov.my/press-release -> mapped_urls=0
- KOMINFO map from https://kominfo.go.id/siaran-pers and /feed -> mapped_urls=0

## Pending: BNM and KOMINFO (next actions)
- BNM: CloudFront 403 for press-release and sitemap. Next options: dedicated egress or allowlist, or test text-only HTTP (no JS) against article detail slugs discovered from third-party references; consider RSS via media partners if any.
- KOMINFO: HEAD/GET returned 000 (edge/network). Next options: increase waitFor to 15000, enforce proxy=stealth, add CSS selectors for .post/.entry content, and test alternate feeds (e.g., /?feed=rss2) if available.

This PR keeps code unchanged (config + docs only).