### PR TITLE
chore(acceptance): end-to-end Deal‑Matching acceptance runner + importer parsing fix

### DIFF
--- a/app/importer.py
+++ b/app/importer.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+Deal-Matching MVP Importer
+
+Usage:
+  python app/importer.py projects --csv=path/to/projects.csv [--allow-new]
+  python app/importer.py investors --csv=path/to/investors.csv [--allow-new]
+
+- Validates against configs/vocab.yaml (unless --allow-new)
+- Upserts by natural key:
+    projects: (sponsor_name, country_iso3, technology, expected_cod)
+    investors: (name)
+- Builds embeddings from free_text (fallback constructed text) using text-embedding-3-small if OPENAI_API_KEY is set.
+- Prints JSON metrics to stdout and exits non-zero on errors.
+"""
+from __future__ import annotations
+import argparse, csv, json, os, sys, datetime as dt
+from typing import Dict, List, Any, Optional
+
+from pathlib import Path
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+except Exception:
+    pass
+
+import psycopg2
+import yaml
+
+# Optional deps
+try:
+    from langdetect import detect  # type: ignore
+except Exception:
+    def detect(_t: str) -> str:
+        return "en"
+
+try:
+    from openai import OpenAI  # type: ignore
+except Exception:
+    OpenAI = None  # type: ignore
+
+
+def openai_client() -> Optional[Any]:
+    key = os.getenv("OPENAI_API_KEY")
+    if not key or OpenAI is None:
+        return None
+    try:
+        return OpenAI(api_key=key)
+    except Exception:
+        return None
+
+
+def embed_text(oa, text: str) -> Optional[List[float]]:
+    try:
+        model = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
+        resp = oa.embeddings.create(model=model, input=(text or "")[:6000])
+        return resp.data[0].embedding  # type: ignore
+    except Exception:
+        return None
+
+
+def summarize_en(oa, text: str) -> str:
+    try:
+        model = os.getenv("OPENAI_SUMMARY_MODEL", "gpt-4o-mini")
+        sys_prompt = (
+            "Summarize the following content in English with 3-5 concise sentences. "
+            "Reply only with the summary."
+        )
+        resp = oa.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": text[:8000]},
+            ],
+        )
+        return (resp.choices[0].message.content or "").strip()
+    except Exception:
+        return text
+
+
+def load_vocab() -> Dict[str, List[str]]:
+    path = os.path.join("configs", "vocab.yaml")
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def get_db():
+    url = os.getenv("NEON_DATABASE_URL")
+    if not url:
+        print("ERROR: NEON_DATABASE_URL not set", file=sys.stderr)
+        sys.exit(2)
+    conn = psycopg2.connect(url)
+    conn.autocommit = True
+    return conn
+
+
+def norm_iso3(x: Optional[str]) -> Optional[str]:
+    if not x: return None
+    x = x.strip().upper()
+    # Accept 2-letter to 3-letter mapping minimal for SG/ID/TH/VN/PH/MY
+    m = {"SG":"SGP","ID":"IDN","TH":"THA","VN":"VNM","PH":"PHL","MY":"MYS"}
+    return m.get(x, x)
+
+
+def to_vector_literal(vec: Optional[List[float]]) -> Optional[str]:
+    if not vec:
+        return None
+    return "[" + ",".join(f"{v:.8f}" for v in vec) + "]"
+
+
+def validate_value(vocab: Dict[str, List[str]], key: str, val: Optional[str], allow_new: bool) -> Optional[str]:
+    if allow_new or val is None or val == "":
+        return val
+    arr = vocab.get(key) or []
+    if key == "countries_iso3":
+        if val and val.upper() not in arr:
+            raise ValueError(f"Invalid country_iso3 '{val}' (allowed: {arr})")
+        return val.upper()
+    if key in ("technologies", "stages", "instruments", "themes", "ifc_categories"):
+        if val and val not in arr:
+            raise ValueError(f"Invalid {key[:-1]} '{val}' (allowed: {arr})")
+        return val
+    return val
+
+
+def projects_import(csv_path: str, allow_new: bool) -> None:
+    vocab = load_vocab()
+    oa = openai_client()
+    conn = get_db()
+    rows_read = upserts = errs = skipped = 0
+
+    required = ["sponsor_name", "country_iso3", "technology", "expected_cod"]
+
+    with open(csv_path, "r", encoding="utf-8-sig") as f, conn.cursor() as cur:
+        r = csv.DictReader(f)
+        missing = [c for c in required if c not in (r.fieldnames or [])]
+        if missing:
+            print(json.dumps({"error": f"Missing column(s): {', '.join(missing)}"}), file=sys.stderr)
+            sys.exit(1)
+        for row in r:
+            rows_read += 1
+            try:
+                sponsor_name = (row.get("sponsor_name") or "").strip()
+                country_iso3 = norm_iso3(row.get("country_iso3"))
+                technology = (row.get("technology") or "").strip()
+                expected_cod = (row.get("expected_cod") or "").strip()
+                if not (sponsor_name and country_iso3 and technology and expected_cod):
+                    skipped += 1
+                    continue
+                # vocab validations
+                country_iso3 = validate_value(vocab, "countries_iso3", country_iso3, allow_new)
+                technology = validate_value(vocab, "technologies", technology, allow_new)
+                stage = validate_value(vocab, "stages", (row.get("stage") or "").strip() or None, allow_new)
+                instrument_needed = validate_value(vocab, "instruments", (row.get("instrument_needed") or "").strip() or None, allow_new)
+                ifc_category = validate_value(vocab, "ifc_categories", (row.get("ifc_category") or "").strip() or None, allow_new)
+
+                free_text = (row.get("free_text") or "").strip()
+                if not free_text:
+                    parts = [sponsor_name, country_iso3, technology, (row.get("capacity_value") or ""), (row.get("capacity_unit") or ""), (stage or ""), (instrument_needed or "")]
+                    free_text = " ".join(p for p in parts if p)
+                try:
+                    lang = detect(free_text or "")
+                except Exception:
+                    lang = "en"
+                if lang != "en" and oa:
+                    free_text = summarize_en(oa, free_text)
+
+                emb = embed_text(oa, free_text) if oa else None
+                emb_lit = to_vector_literal(emb)
+
+                # Parse numerics
+                def num(x):
+                    try:
+                        return float(x) if x not in (None, "") else None
+                    except Exception:
+                        return None
+                def dec(x):
+                    try:
+                        return float(x) if x not in (None, "") else None
+                    except Exception:
+                        return None
+
+                params = {
+                    "sponsor_name": sponsor_name,
+                    "country_iso3": country_iso3,
+                    "lat": num(row.get("lat")),
+                    "lng": num(row.get("lng")),
+                    "technology": technology,
+                    "capacity_value": num(row.get("capacity_value")),
+                    "capacity_unit": (row.get("capacity_unit") or None),
+                    "expected_cod": dt.date.fromisoformat(expected_cod),
+                    "stage": stage,
+                    "capex_usd": dec(row.get("capex_usd")),
+                    "ticket_open_usd": dec(row.get("ticket_open_usd")),
+                    "instrument_needed": instrument_needed,
+                    "currency": (row.get("currency") or None),
+                    "tenor_years": dec(row.get("tenor_years")),
+                    "target_irr": dec(row.get("target_irr")),
+                    "offtake_status": (row.get("offtake_status") or None),
+                    "permits_status": (row.get("permits_status") or None),
+                    "land_rights_status": (row.get("land_rights_status") or None),
+                    "grid_interconnect_status": (row.get("grid_interconnect_status") or None),
+                    "esia_status": (row.get("esia_status") or None),
+                    "ifc_category": ifc_category,
+                    "community_risk": (row.get("community_risk") or None),
+                    "pri_possible": (str(row.get("pri_possible")).lower() == "true"),
+                    "eca_possible": (str(row.get("eca_possible")).lower() == "true"),
+                    "sovereign_support": (str(row.get("sovereign_support")).lower() == "true"),
+                    "policy_alignment": (row.get("policy_alignment") or None),
+                    "china_plus_one_fit": (str(row.get("china_plus_one_fit")).lower() == "true"),
+                    "nda_signed": (str(row.get("nda_signed")).lower() == "true"),
+                    "data_room_url": (row.get("data_room_url") or None),
+                    "free_text": free_text,
+                    "embedding": emb_lit,
+                }
+
+                sql = (
+                    "INSERT INTO projects (sponsor_name,country_iso3,lat,lng,technology,capacity_value,capacity_unit,expected_cod,stage,capex_usd,"
+                    "ticket_open_usd,instrument_needed,currency,tenor_years,target_irr,offtake_status,permits_status,land_rights_status,grid_interconnect_status,esia_status,"
+                    "ifc_category,community_risk,pri_possible,eca_possible,sovereign_support,policy_alignment,china_plus_one_fit,nda_signed,data_room_url,free_text,embedding)"
+                    " VALUES (%(sponsor_name)s,%(country_iso3)s,%(lat)s,%(lng)s,%(technology)s,%(capacity_value)s,%(capacity_unit)s,%(expected_cod)s,%(stage)s,%(capex_usd)s,"
+                    "%(ticket_open_usd)s,%(instrument_needed)s,%(currency)s,%(tenor_years)s,%(target_irr)s,%(offtake_status)s,%(permits_status)s,%(land_rights_status)s,%(grid_interconnect_status)s,%(esia_status)s,"
+                    "%(ifc_category)s,%(community_risk)s,%(pri_possible)s,%(eca_possible)s,%(sovereign_support)s,%(policy_alignment)s,%(china_plus_one_fit)s,%(nda_signed)s,%(data_room_url)s,%(free_text)s,"
+                    + ("%(embedding)s::vector" if emb_lit else "NULL") + ") "
+                    "ON CONFLICT (sponsor_name,country_iso3,technology,expected_cod) DO UPDATE SET "
+                    "stage=EXCLUDED.stage, capex_usd=EXCLUDED.capex_usd, ticket_open_usd=EXCLUDED.ticket_open_usd, instrument_needed=EXCLUDED.instrument_needed, "
+                    "currency=EXCLUDED.currency, tenor_years=EXCLUDED.tenor_years, target_irr=EXCLUDED.target_irr, offtake_status=EXCLUDED.offtake_status, "
+                    "permits_status=EXCLUDED.permits_status, land_rights_status=EXCLUDED.land_rights_status, grid_interconnect_status=EXCLUDED.grid_interconnect_status, esia_status=EXCLUDED.esia_status, "
+                    "ifc_category=EXCLUDED.ifc_category, community_risk=EXCLUDED.community_risk, pri_possible=EXCLUDED.pri_possible, eca_possible=EXCLUDED.eca_possible, sovereign_support=EXCLUDED.sovereign_support, "
+                    "policy_alignment=EXCLUDED.policy_alignment, china_plus_one_fit=EXCLUDED.china_plus_one_fit, nda_signed=EXCLUDED.nda_signed, data_room_url=EXCLUDED.data_room_url, free_text=EXCLUDED.free_text"
+                    + (", embedding=EXCLUDED.embedding" if emb_lit else "") +
+                    ";"
+                )
+                cur.execute(sql, params)
+                upserts += 1
+            except Exception as e:
+                errs += 1
+                print(json.dumps({"row": rows_read, "error": str(e)}), file=sys.stderr)
+                continue
+
+    print(json.dumps({"rows_read": rows_read, "upserts": upserts, "errors": errs, "skipped": skipped}))
+    if errs:
+        sys.exit(1)
+
+
+def parse_list(val: Optional[str]) -> Optional[List[str]]:
+    if val is None or val == "":
+        return None
+    if isinstance(val, list):
+        return [str(x).strip() for x in val if str(x).strip()]
+    s = str(val).strip()
+    # Strip surrounding braces/brackets like "{a,b}" or "[a,b]"
+    if (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]")):
+        s = s[1:-1]
+    # Prefer pipe '|' when present; otherwise fall back to comma splitting
+    parts_pipe = [x.strip() for x in s.split("|") if x.strip()]
+    if len(parts_pipe) <= 1 and ("," in s):
+        parts = [x.strip() for x in s.split(",") if x.strip()]
+    else:
+        parts = parts_pipe
+    return parts or None
+
+
+def investors_import(csv_path: str, allow_new: bool) -> None:
+    vocab = load_vocab()
+    oa = openai_client()
+    conn = get_db()
+    rows_read = upserts = errs = skipped = 0
+
+    required = ["name", "type"]
+
+    with open(csv_path, "r", encoding="utf-8-sig") as f, conn.cursor() as cur:
+        r = csv.DictReader(f)
+        missing = [c for c in required if c not in (r.fieldnames or [])]
+        if missing:
+            print(json.dumps({"error": f"Missing column(s): {', '.join(missing)}"}), file=sys.stderr)
+            sys.exit(1)
+        for row in r:
+            rows_read += 1
+            try:
+                name = (row.get("name") or "").strip()
+                typ = (row.get("type") or "").strip()
+                if not (name and typ):
+                    skipped += 1
+                    continue
+                # vocab validations
+                _ = validate_value(vocab, "instruments", None, True)  # no-op; ensures vocab loads
+
+                free_text = (row.get("free_text") or "").strip()
+                if not free_text:
+                    parts = [name, typ, (row.get("themes") or ""), (row.get("instruments_offered") or ""), (row.get("notes") or "")]
+                    free_text = " ".join(p for p in parts if p)
+                try:
+                    lang = detect(free_text or "")
+                except Exception:
+                    lang = "en"
+                if lang != "en" and oa:
+                    free_text = summarize_en(oa, free_text)
+
+                emb = embed_text(oa, free_text) if oa else None
+                emb_lit = to_vector_literal(emb)
+
+                def dec(x):
+                    try:
+                        return float(x) if x not in (None, "") else None
+                    except Exception:
+                        return None
+
+                params = {
+                    "name": name,
+                    "type": typ,
+                    "mandate_regions": parse_list(row.get("mandate_regions")),
+                    "mandate_technologies": parse_list(row.get("mandate_technologies")),
+                    "use_of_proceeds_allowed": parse_list(row.get("use_of_proceeds_allowed")),
+                    "instruments_offered": parse_list(row.get("instruments_offered")),
+                    "min_ticket_usd": dec(row.get("min_ticket_usd")),
+                    "max_ticket_usd": dec(row.get("max_ticket_usd")),
+                    "min_tenor_years": dec(row.get("min_tenor_years")),
+                    "max_tenor_years": dec(row.get("max_tenor_years")),
+                    "target_irr_range": (row.get("target_irr_range") or None),
+                    "risk_appetite": (row.get("risk_appetite") or None),
+                    "ifc_category_allowed": parse_list(row.get("ifc_category_allowed")),
+                    "coal_exclusion": (str(row.get("coal_exclusion")).lower() == "true"),
+                    "other_exclusions": parse_list(row.get("other_exclusions")),
+                    "lending_currencies": parse_list(row.get("lending_currencies")),
+                    "local_currency_pref": (str(row.get("local_currency_pref")).lower() == "true"),
+                    "requires_site_visit": (str(row.get("requires_site_visit")).lower() == "true"),
+                    "requires_ifc_ps": (str(row.get("requires_ifc_ps")).lower() == "true"),
+                    "avg_decision_time_days": int(float(row.get("avg_decision_time_days"))) if (row.get("avg_decision_time_days") or "").strip() else None,
+                    "themes": parse_list(row.get("themes")),
+                    "contacts": (json.loads(row.get("contacts_json")) if row.get("contacts_json") else None),
+                    "notes": (row.get("notes") or None),
+                    "free_text": free_text,
+                    "embedding": emb_lit,
+                }
+
+                sql = (
+                    "INSERT INTO investors (name,type,mandate_regions,mandate_technologies,use_of_proceeds_allowed,instruments_offered,min_ticket_usd,max_ticket_usd,min_tenor_years,max_tenor_years,"
+                    "target_irr_range,risk_appetite,ifc_category_allowed,coal_exclusion,other_exclusions,lending_currencies,local_currency_pref,requires_site_visit,requires_ifc_ps,avg_decision_time_days,themes,contacts,notes,free_text,embedding) "
+                    "VALUES (%(name)s,%(type)s,%(mandate_regions)s,%(mandate_technologies)s,%(use_of_proceeds_allowed)s,%(instruments_offered)s,%(min_ticket_usd)s,%(max_ticket_usd)s,%(min_tenor_years)s,%(max_tenor_years)s,"
+                    "%(target_irr_range)s,%(risk_appetite)s,%(ifc_category_allowed)s,%(coal_exclusion)s,%(other_exclusions)s,%(lending_currencies)s,%(local_currency_pref)s,%(requires_site_visit)s,%(requires_ifc_ps)s,%(avg_decision_time_days)s,%(themes)s,%(contacts)s,%(notes)s,%(free_text)s,"
+                    + ("%(embedding)s::vector" if emb_lit else "NULL") + ") "
+                    "ON CONFLICT (name) DO UPDATE SET "
+                    "type=EXCLUDED.type, mandate_regions=EXCLUDED.mandate_regions, mandate_technologies=EXCLUDED.mandate_technologies, instruments_offered=EXCLUDED.instruments_offered, "
+                    "min_ticket_usd=EXCLUDED.min_ticket_usd, max_ticket_usd=EXCLUDED.max_ticket_usd, min_tenor_years=EXCLUDED.min_tenor_years, max_tenor_years=EXCLUDED.max_tenor_years, "
+                    "target_irr_range=EXCLUDED.target_irr_range, risk_appetite=EXCLUDED.risk_appetite, ifc_category_allowed=EXCLUDED.ifc_category_allowed, coal_exclusion=EXCLUDED.coal_exclusion, other_exclusions=EXCLUDED.other_exclusions, "
+                    "lending_currencies=EXCLUDED.lending_currencies, local_currency_pref=EXCLUDED.local_currency_pref, requires_site_visit=EXCLUDED.requires_site_visit, requires_ifc_ps=EXCLUDED.requires_ifc_ps, avg_decision_time_days=EXCLUDED.avg_decision_time_days, themes=EXCLUDED.themes, notes=EXCLUDED.notes, free_text=EXCLUDED.free_text"
+                    + (", embedding=EXCLUDED.embedding" if emb_lit else "") +
+                    ";"
+                )
+                cur.execute(sql, params)
+                upserts += 1
+            except Exception as e:
+                errs += 1
+                print(json.dumps({"row": rows_read, "error": str(e)}), file=sys.stderr)
+                continue
+
+    print(json.dumps({"rows_read": rows_read, "upserts": upserts, "errors": errs, "skipped": skipped}))
+
+
+def project_yaml_import(in_path: str, allow_new: bool) -> None:
+    vocab = load_vocab()
+    oa = openai_client()
+    conn = get_db()
+    rows_read = upserts = errs = skipped = 0
+    try:
+        with open(in_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        rows_read = 1
+        sponsor_name = (data.get("sponsor_name") or "").strip()
+        country_iso3 = norm_iso3(data.get("country_iso3"))
+        technology = (data.get("technology") or "").strip()
+        expected_cod = (data.get("expected_cod") or "").strip()
+        if not (sponsor_name and country_iso3 and technology and expected_cod):
+            print(json.dumps({"error": "Missing required fields in YAML: sponsor_name, country_iso3, technology, expected_cod"}), file=sys.stderr)
+            sys.exit(1)
+        country_iso3 = validate_value(vocab, "countries_iso3", country_iso3, allow_new)
+        technology = validate_value(vocab, "technologies", technology, allow_new)
+        stage = validate_value(vocab, "stages", (data.get("stage") or None), allow_new)
+        instrument_needed = validate_value(vocab, "instruments", (data.get("instrument_needed") or None), allow_new)
+        ifc_category = validate_value(vocab, "ifc_categories", (data.get("ifc_category") or None), allow_new)
+        free_text = (data.get("free_text") or data.get("notes") or "").strip()
+        if not free_text:
+            parts = [sponsor_name, country_iso3, technology, str(data.get("capacity_value") or ""), str(data.get("capacity_unit") or ""), (stage or ""), (instrument_needed or "")]
+            free_text = " ".join(p for p in parts if p)
+        try:
+            lang = detect(free_text or "")
+        except Exception:
+            lang = "en"
+        if lang != "en" and oa:
+            free_text = summarize_en(oa, free_text)
+        emb = embed_text(oa, free_text) if oa else None
+        emb_lit = to_vector_literal(emb)
+        def num(x):
+            try:
+                return float(x) if x not in (None, "") else None
+            except Exception:
+                return None
+        def dec(x):
+            try:
+                return float(x) if x not in (None, "") else None
+            except Exception:
+                return None
+        params = {
+            "sponsor_name": sponsor_name,
+            "country_iso3": country_iso3,
+            "lat": num(data.get("lat")),
+            "lng": num(data.get("lng")),
+            "technology": technology,
+            "capacity_value": num(data.get("capacity_value")),
+            "capacity_unit": (data.get("capacity_unit") or None),
+            "expected_cod": dt.date.fromisoformat(expected_cod),
+            "stage": stage,
+            "capex_usd": dec(data.get("capex_usd")),
+            "ticket_open_usd": dec(data.get("ticket_open_usd")),
+            "instrument_needed": instrument_needed,
+            "currency": (data.get("currency") or None),
+            "tenor_years": dec(data.get("tenor_years")),
+            "target_irr": dec(data.get("target_irr")),
+            "offtake_status": (data.get("offtake_status") or None),
+            "permits_status": (data.get("permits_status") or None),
+            "land_rights_status": (data.get("land_rights_status") or None),
+            "grid_interconnect_status": (data.get("grid_interconnect_status") or None),
+            "esia_status": (data.get("esia_status") or None),
+            "ifc_category": ifc_category,
+            "community_risk": (data.get("community_risk") or None),
+            "pri_possible": (str(data.get("pri_possible")).lower() == "true"),
+            "eca_possible": (str(data.get("eca_possible")).lower() == "true"),
+            "sovereign_support": (str(data.get("sovereign_support")).lower() == "true"),
+            "policy_alignment": data.get("policy_alignment") if isinstance(data.get("policy_alignment"), list) else (parse_list(data.get("policy_alignment")) or None),
+            "china_plus_one_fit": (str(data.get("china_plus_one_fit")).lower() == "true"),
+            "nda_signed": (str(data.get("nda_signed")).lower() == "true"),
+            "data_room_url": (data.get("data_room_url") or data.get("dataroom_url") or None),
+            "free_text": free_text,
+            "embedding": emb_lit,
+        }
+        with conn.cursor() as cur:
+            sql = (
+                "INSERT INTO projects (sponsor_name,country_iso3,lat,lng,technology,capacity_value,capacity_unit,expected_cod,stage,capex_usd,"
+                "ticket_open_usd,instrument_needed,currency,tenor_years,target_irr,offtake_status,permits_status,land_rights_status,grid_interconnect_status,esia_status,"
+                "ifc_category,community_risk,pri_possible,eca_possible,sovereign_support,policy_alignment,china_plus_one_fit,nda_signed,data_room_url,free_text,embedding)"
+                " VALUES (%(sponsor_name)s,%(country_iso3)s,%(lat)s,%(lng)s,%(technology)s,%(capacity_value)s,%(capacity_unit)s,%(expected_cod)s,%(stage)s,%(capex_usd)s,"
+                "%(ticket_open_usd)s,%(instrument_needed)s,%(currency)s,%(tenor_years)s,%(target_irr)s,%(offtake_status)s,%(permits_status)s,%(land_rights_status)s,%(grid_interconnect_status)s,%(esia_status)s,"
+                "%(ifc_category)s,%(community_risk)s,%(pri_possible)s,%(eca_possible)s,%(sovereign_support)s,%(policy_alignment)s,%(china_plus_one_fit)s,%(nda_signed)s,%(data_room_url)s,%(free_text)s,"
+                + ("%(embedding)s::vector" if emb_lit else "NULL") + ") "
+                "ON CONFLICT (sponsor_name,country_iso3,technology,expected_cod) DO UPDATE SET "
+                "stage=EXCLUDED.stage, capex_usd=EXCLUDED.capex_usd, ticket_open_usd=EXCLUDED.ticket_open_usd, instrument_needed=EXCLUDED.instrument_needed, "
+                "currency=EXCLUDED.currency, tenor_years=EXCLUDED.tenor_years, target_irr=EXCLUDED.target_irr, offtake_status=EXCLUDED.offtake_status, "
+                "permits_status=EXCLUDED.permits_status, land_rights_status=EXCLUDED.land_rights_status, grid_interconnect_status=EXCLUDED.grid_interconnect_status, esia_status=EXCLUDED.esia_status, "
+                "ifc_category=EXCLUDED.ifc_category, community_risk=EXCLUDED.community_risk, pri_possible=EXCLUDED.pri_possible, eca_possible=EXCLUDED.eca_possible, sovereign_support=EXCLUDED.sovereign_support, "
+                "policy_alignment=EXCLUDED.policy_alignment, china_plus_one_fit=EXCLUDED.china_plus_one_fit, nda_signed=EXCLUDED.nda_signed, data_room_url=EXCLUDED.data_room_url, free_text=EXCLUDED.free_text"
+                + (", embedding=EXCLUDED.embedding" if emb_lit else "") +
+                ";"
+            )
+            cur.execute(sql, params)
+            upserts = 1
+    except Exception as e:
+        errs = 1
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+    print(json.dumps({"rows_read": rows_read, "upserts": upserts, "errors": errs, "skipped": skipped}))
+    if errs:
+        sys.exit(1)
+
+    if errs:
+        sys.exit(1)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Importer for projects/investors")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    p1 = sub.add_parser("projects", help="Import projects CSV")
+    p1.add_argument("--csv", required=True)
+    p1.add_argument("--allow-new", action="store_true")
+    p2 = sub.add_parser("investors", help="Import investors CSV")
+    p2.add_argument("--csv", required=True)
+    p2.add_argument("--allow-new", action="store_true")
+    p3 = sub.add_parser("project-yaml", help="Import a single project from YAML")
+    p3.add_argument("--in", dest="in_path", required=True)
+    p3.add_argument("--allow-new", action="store_true")
+    args = p.parse_args()
+
+    if args.cmd == "projects":
+        projects_import(args.csv, args.allow_new)
+    elif args.cmd == "investors":
+        investors_import(args.csv, args.allow_new)
+    elif args.cmd == "project-yaml":
+        project_yaml_import(args.in_path, args.allow_new)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/app/matcher.py
+++ b/app/matcher.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Deal-Matching MVP Matcher
+
+Usage:
+  python app/matcher.py rank --project-id=<uuid> --top=10
+  python app/matcher.py batch --min-score=60 --top=5
+
+- Applies hard filters then soft scoring (0-100)
+- Upserts into matches table (idempotent by project_id, investor_id)
+- Prints a Markdown summary of top matches
+"""
+from __future__ import annotations
+import argparse, json, math, os, sys, datetime as dt
+from typing import List, Dict, Any, Optional, Tuple
+
+from pathlib import Path
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+except Exception:
+    pass
+
+import psycopg2
+
+
+import yaml
+
+_WEIGHTS_CACHE = None
+_VOCAB_CACHE = None
+
+
+def load_weights() -> dict:
+    global _WEIGHTS_CACHE
+    if _WEIGHTS_CACHE is not None:
+        return _WEIGHTS_CACHE
+    defaults = {"mandate": 0.25, "readiness": 0.20, "commercials": 0.20, "risk": 0.15, "impact": 0.10, "strategic": 0.10}
+    try:
+        with open("configs/weights.yaml", "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+            # Coerce and fill defaults
+            out = {k: float(data.get(k, defaults[k])) for k in defaults.keys()}
+            _WEIGHTS_CACHE = out
+            return out
+    except Exception:
+        _WEIGHTS_CACHE = defaults
+        return defaults
+
+
+def load_vocab() -> dict:
+    global _VOCAB_CACHE
+    if _VOCAB_CACHE is not None:
+        return _VOCAB_CACHE
+    try:
+        with open("configs/vocab.yaml", "r", encoding="utf-8") as f:
+            _VOCAB_CACHE = yaml.safe_load(f) or {}
+            return _VOCAB_CACHE
+    except Exception:
+        _VOCAB_CACHE = {}
+        return {}
+
+def get_db():
+    url = os.getenv("NEON_DATABASE_URL")
+    if not url:
+        print("ERROR: NEON_DATABASE_URL not set", file=sys.stderr)
+        sys.exit(2)
+    conn = psycopg2.connect(url)
+    conn.autocommit = True
+    return conn
+
+
+def cosine(a: Optional[List[float]], b: Optional[List[float]]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x*y for x,y in zip(a,b))
+    na = math.sqrt(sum(x*x for x in a))
+    nb = math.sqrt(sum(y*y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot/(na*nb)
+
+
+def parse_vector(val) -> Optional[List[float]]:
+    # Accept psycopg2 returning string like "[0.1,0.2,...]" or list
+    if val is None:
+        return None
+    if isinstance(val, list):
+        return [float(x) for x in val]
+    s = str(val).strip()
+    if s.startswith("[") and s.endswith("]"):
+        try:
+            return [float(x) for x in s[1:-1].split(',') if x.strip()]
+        except Exception:
+            return None
+    return None
+
+
+# ---------------- Scoring ----------------
+
+def readiness_score(p: Dict[str, Any]) -> float:
+    # permits_status, land_rights_status, grid_interconnect_status, esia_status
+    def level(x: Optional[str]) -> int:
+        x = (x or "").lower()
+        if x in ("final","executed","secured","granted","complete"): return 3
+        if x in ("draft","loi","applied","in_progress"): return 2
+        if x in ("scoping","none","pending","unknown"): return 1
+        return 0
+    vals = [level(p.get("permits_status")), level(p.get("land_rights_status")), level(p.get("grid_interconnect_status")), level(p.get("esia_status"))]
+    return (sum(vals)/ (3*4)) * 20.0  # max 20
+
+
+def commercials_score(p: Dict[str, Any], inv: Dict[str, Any]) -> float:
+    score = 0.0
+    # ticket within range tightness
+    t = p.get("ticket_open_usd")
+    if t is not None:
+        lo = inv.get("min_ticket_usd")
+        hi = inv.get("max_ticket_usd")
+        if lo is not None and hi is not None:
+            mid = (float(lo)+float(hi))/2.0
+            span = max(1.0, float(hi)-float(lo))
+            score += max(0.0, 10.0 * (1.0 - min(1.0, abs(float(t)-mid)/span)))
+        else:
+            score += 6.0
+    # tenor
+    ten = p.get("tenor_years")
+    if ten is not None:
+        lo = inv.get("min_tenor_years")
+        hi = inv.get("max_tenor_years")
+        if lo is not None and hi is not None and float(lo) <= float(ten) <= float(hi):
+            score += 5.0
+    # irr hint
+    if (p.get("target_irr") and inv.get("target_irr_range")):
+        try:
+            low, high = [float(x) for x in str(inv.get("target_irr_range")).replace('%','').split('-')]
+            if low <= float(p.get("target_irr")) <= high:
+                score += 3.0
+        except Exception:
+            pass
+    # currency heuristic
+    if p.get("currency") and inv.get("lending_currencies") and p["currency"] in (inv.get("lending_currencies") or []):
+        score += 2.0
+    return min(20.0, score)
+
+
+def risk_score(p: Dict[str, Any]) -> float:
+    score = 0.0
+    if p.get("pri_possible"): score += 5.0
+    if p.get("eca_possible"): score += 5.0
+    if p.get("sovereign_support"): score += 5.0
+    return min(15.0, score)
+
+
+def impact_score(p: Dict[str, Any], inv: Dict[str, Any]) -> float:
+    score = 0.0
+    # IFC category tolerance
+    cat = (p.get("ifc_category") or "").upper()
+    allowed = [str(x).upper() for x in (inv.get("ifc_category_allowed") or [])]
+    if cat and (not allowed or cat in allowed):
+        score += 6.0
+    # community risk
+    cr = (p.get("community_risk") or "low").lower()
+    score += {"low": 4.0, "med": 2.0, "high": 0.0}.get(cr, 2.0)
+    return min(10.0, score)
+
+
+def strategic_score(p: Dict[str, Any], inv: Dict[str, Any]) -> float:
+    score = 0.0
+    p_themes = set([x.lower() for x in (p.get("policy_alignment") or [])])
+    i_themes = set([x.lower() for x in (inv.get("themes") or [])])
+    if p.get("china_plus_one_fit"): score += 3.0
+    if p_themes and i_themes:
+        score += min(7.0, 1.5 * len(p_themes.intersection(i_themes)))
+    return min(10.0, score)
+
+
+def mandate_score(p: Dict[str, Any], inv: Dict[str, Any]) -> float:
+    score = 0.0
+    # geography
+    if not inv.get("mandate_regions") or (p.get("country_iso3") in (inv.get("mandate_regions") or [])):
+        score += 10.0
+    # technology
+    if not inv.get("mandate_technologies") or (p.get("technology") in (inv.get("mandate_technologies") or [])):
+        score += 10.0
+    # embedding sim (optional)
+    sim = cosine(parse_vector(p.get("embedding")), parse_vector(inv.get("embedding")))
+    score += max(0.0, min(5.0, 5.0 * sim))
+    return min(25.0, score)
+
+
+def hard_filters_pass(p: Dict[str, Any], inv: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    reasons: List[str] = []
+    # 1 Geography
+    regions = inv.get("mandate_regions") or []
+    iso3 = (p.get("country_iso3") or "").upper()
+    regions_u = [str(r).upper() for r in regions]
+    asean_countries = [str(x).upper() for x in (load_vocab().get("countries_iso3") or [])]
+    geo_ok = True
+    if regions_u:
+        geo_ok = (iso3 in regions_u) or ("ASEAN" in regions_u and iso3 in asean_countries)
+    if not geo_ok:
+        reasons.append("geography")
+    # 2 Tech
+    techs = inv.get("mandate_technologies") or []
+    if techs and p.get("technology") not in techs:
+        reasons.append("technology")
+    # 3 Ticket range
+    t = p.get("ticket_open_usd")
+    lo, hi = inv.get("min_ticket_usd"), inv.get("max_ticket_usd")
+    if t is not None and ((lo is not None and float(t) < float(lo)) or (hi is not None and float(t) > float(hi))):
+        reasons.append("ticket")
+    # 4 Instrument
+    instr = inv.get("instruments_offered") or []
+    if p.get("instrument_needed") and instr and p.get("instrument_needed") not in instr:
+        reasons.append("instrument")
+    # 5 Exclusions
+    if inv.get("coal_exclusion") and (p.get("technology") or "").lower() == "coal":
+        reasons.append("coal_exclusion")
+    allowed = [str(x).upper() for x in (inv.get("ifc_category_allowed") or [])]
+    if p.get("ifc_category") and allowed and str(p.get("ifc_category")).upper() not in allowed:
+        reasons.append("ifc_category")
+    # 6 Stage gates
+    if inv.get("requires_ifc_ps"):
+        st = (p.get("esia_status") or "").lower()
+        if st not in ("draft","final"):
+            reasons.append("ifc_ps_stage")
+    return (len(reasons) == 0), reasons
+
+
+def fetch_project(conn, pid: str) -> Optional[Dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM projects WHERE project_id=%s", (pid,))
+        row = cur.fetchone()
+        if not row:
+            return None
+        cols = [d[0] for d in cur.description]
+        return dict(zip(cols, row))
+
+
+def fetch_open_projects(conn) -> List[Dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM projects WHERE COALESCE(ticket_open_usd,0) > 0 AND COALESCE(stage,'') <> 'financial-close'")
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in rows]
+
+
+def fetch_investors(conn) -> List[Dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM investors")
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in rows]
+
+
+def build_explain(p: Dict[str, Any], inv: Dict[str, Any], passed_filters: bool, failed: List[str], total: float) -> Tuple[List[str], List[str], str]:
+    drivers: List[str] = []
+    blockers: List[str] = []
+    if not inv.get("mandate_regions") or p.get("country_iso3") in (inv.get("mandate_regions") or []):
+        drivers.append(f"Geography match: {p.get('country_iso3')} in mandate")
+    else:
+        blockers.append("Geography outside mandate")
+    if not inv.get("mandate_technologies") or p.get("technology") in (inv.get("mandate_technologies") or []):
+        drivers.append(f"Technology fit: {p.get('technology')}")
+    else:
+        blockers.append("Technology outside mandate")
+    if p.get("permits_status") in ("draft","final","granted","secured"):
+        drivers.append("Readiness: permits progressing")
+    if p.get("land_rights_status") in ("draft","final","granted","secured"):
+        drivers.append("Readiness: land rights progressing")
+    if p.get("grid_interconnect_status") in ("draft","final","granted","secured"):
+        drivers.append("Readiness: grid interconnect progressing")
+    if p.get("esia_status") not in ("draft","final"):
+        blockers.append("ESIA not yet draft/final")
+    if p.get("pri_possible"): drivers.append("PRI possible")
+    if p.get("eca_possible"): drivers.append("ECA possible")
+    if p.get("sovereign_support"): drivers.append("Sovereign support")
+    if inv.get("requires_ifc_ps") and p.get("esia_status") not in ("draft","final"):
+        blockers.append("IFC PS required: advance ESIA")
+    # next action heuristic
+    next_action = ""
+    if "ifc_ps_stage" in failed or p.get("esia_status") not in ("draft","final"):
+        next_action = "Finalize ESIA"
+    elif (p.get("grid_interconnect_status") or "").lower() not in ("draft","final","granted","secured"):
+        next_action = "Obtain grid interconnect letter"
+    elif not drivers:
+        next_action = "Share teaser and request mandate fit feedback"
+    return (drivers[:5], blockers[:2], next_action)
+
+
+def score_one(p: Dict[str, Any], inv: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    ok, failed = hard_filters_pass(p, inv)
+    if not ok:
+        return None
+    w = load_weights()
+    m = mandate_score(p, inv)        # max 25
+    rd = readiness_score(p)          # max 20
+    cm = commercials_score(p, inv)   # max 20
+    rk = risk_score(p)               # max 15
+    im = impact_score(p, inv)        # max 10
+    st = strategic_score(p, inv)     # max 10
+    total = 100.0 * (
+        w.get("mandate", 0.25)   * (m / 25.0) +
+        w.get("readiness", 0.20) * (rd / 20.0) +
+        w.get("commercials", 0.20) * (cm / 20.0) +
+        w.get("risk", 0.15)      * (rk / 15.0) +
+        w.get("impact", 0.10)    * (im / 10.0) +
+        w.get("strategic", 0.10) * (st / 10.0)
+    )
+    total = max(0.0, min(100.0, total))
+    drivers, blockers, next_action = build_explain(p, inv, True, [], total)
+    return {
+        "investor": inv,
+        "score": total,
+        "drivers": drivers,
+        "blockers": blockers,
+        "next_action": next_action,
+    }
+
+
+def upsert_match(conn, project_id: str, investor_id: str, score: float, drivers: List[str], blockers: List[str], next_action: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO matches (project_id, investor_id, score_numeric, drivers, blockers, next_action)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (project_id, investor_id) DO UPDATE SET
+              score_numeric = EXCLUDED.score_numeric,
+              drivers = EXCLUDED.drivers,
+              blockers = EXCLUDED.blockers,
+              next_action = EXCLUDED.next_action,
+              created_at = NOW()
+            """,
+            (project_id, investor_id, float(score), drivers, blockers, next_action)
+        )
+
+
+def print_markdown(project: Dict[str, Any], matches: List[Dict[str, Any]], top: int) -> None:
+    topn = matches[:top]
+    print("## Top Matches")
+    for m in topn:
+        inv = m["investor"]
+        print(f"- Investor: {inv.get('name')} ({inv.get('type')}) — Score: {m['score']:.1f}")
+        print("  - Drivers:")
+        for d in m["drivers"]:
+            print(f"    - {d}")
+        if m["blockers"]:
+            print("  - Blockers:")
+            for b in m["blockers"]:
+                print(f"    - {b}")
+        if m["next_action"]:
+            print(f"  - Next Action: {m['next_action']}")
+    print()
+
+
+def cmd_rank(conn, project_id: str, top: int) -> int:
+    p = fetch_project(conn, project_id)
+    if not p:
+        print(f"ERROR: project_id not found: {project_id}", file=sys.stderr)
+        return 1
+    investors = fetch_investors(conn)
+    scored: List[Dict[str, Any]] = []
+    for inv in investors:
+        res = score_one(p, inv)
+        if res:
+            scored.append(res)
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    for m in scored[:top]:
+        upsert_match(conn, p["project_id"], m["investor"]["investor_id"], m["score"], m["drivers"], m["blockers"], m["next_action"])
+    print_markdown(p, scored, top)
+    print(json.dumps({"project_id": project_id, "considered": len(investors), "matched": len(scored[:top])}))
+    return 0
+
+
+def cmd_batch(conn, min_score: float, top: int) -> int:
+    projects = fetch_open_projects(conn)
+    investors = fetch_investors(conn)
+    total_matches = 0
+    for p in projects:
+        scored: List[Dict[str, Any]] = []
+        for inv in investors:
+            res = score_one(p, inv)
+            if res and res["score"] >= float(min_score):
+                scored.append(res)
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        keep = scored[:top]
+        for m in keep:
+            upsert_match(conn, p["project_id"], m["investor"]["investor_id"], m["score"], m["drivers"], m["blockers"], m["next_action"])
+        total_matches += len(keep)
+        if keep:
+            print(f"### Project: {p.get('sponsor_name')} — {p.get('country_iso3')} — {p.get('technology')} — {p.get('capacity_value')} {p.get('capacity_unit')}")
+            print_markdown(p, keep, top)
+    print(json.dumps({"projects": len(projects), "total_matches": total_matches, "min_score": min_score, "top": top}))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Matcher CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_rank = sub.add_parser("rank", help="Rank investors for a given project")
+    p_rank.add_argument("--project-id", required=True)
+    p_rank.add_argument("--top", type=int, default=10)
+
+    p_batch = sub.add_parser("batch", help="Batch match for all open projects")
+    p_batch.add_argument("--min-score", type=float, default=60)
+    p_batch.add_argument("--top", type=int, default=5)
+
+    args = ap.parse_args()
+    conn = get_db()
+    if args.cmd == "rank":
+        rc = cmd_rank(conn, args.project_id, args.top)
+        sys.exit(rc)
+    elif args.cmd == "batch":
+        rc = cmd_batch(conn, args.min_score, args.top)
+        sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/app/report_stub.py
+++ b/app/report_stub.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Report Stub Extensions
+
+Usage:
+  python app/report_stub.py matches --since-days=1 --top=3
+
+Emits a markdown section summarizing top matches created in the last N days.
+"""
+from __future__ import annotations
+import argparse, os, sys, datetime as dt
+from typing import List, Dict, Any
+
+from pathlib import Path
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+except Exception:
+    pass
+
+import psycopg2
+
+
+def get_db():
+    url = os.getenv("NEON_DATABASE_URL")
+    if not url:
+        print("ERROR: NEON_DATABASE_URL not set", file=sys.stderr)
+        sys.exit(2)
+    conn = psycopg2.connect(url)
+    conn.autocommit = True
+    return conn
+
+
+def fmt_cap(p: Dict[str, Any]) -> str:
+    v = p.get("capacity_value")
+    u = p.get("capacity_unit") or ""
+    return f"{v} {u}" if v is not None else "-"
+
+
+def cmd_matches(since_days: int, top: int) -> int:
+    conn = get_db()
+    since_ts = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=int(since_days))
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT m.score_numeric, m.drivers, m.blockers, m.next_action,
+                   p.project_id, p.sponsor_name, p.country_iso3, p.technology, p.capacity_value, p.capacity_unit, p.data_room_url,
+                   i.investor_id, i.name, i.type
+            FROM matches m
+            JOIN projects p ON p.project_id = m.project_id
+            JOIN investors i ON i.investor_id = m.investor_id
+            WHERE m.created_at >= %s
+            ORDER BY m.score_numeric DESC
+            LIMIT %s
+            """,
+            (since_ts, int(top))
+        )
+        rows = cur.fetchall()
+        if not rows:
+            print("### Top Matches\n\n_No recent matches found._\n")
+            return 0
+        print("### Top Matches\n")
+        print("| Project | Investor | Score | Drivers | Blockers | Next Action | Link |")
+        print("|---|---|---:|---|---|---|---|")
+        for (score, drivers, blockers, next_action, pid, sponsor, iso3, tech, capv, capu, dr_url, iid, iname, itype) in rows:
+            proj = f"{sponsor} ({iso3}) — {tech} — {capv} {capu}"
+            inv = f"{iname} ({itype})"
+            drivers_txt = "; ".join((drivers or [])[:5]) if drivers else ""
+            blockers_txt = "; ".join((blockers or [])[:2]) if blockers else ""
+            link = dr_url or ""
+            print(f"| {proj} | {inv} | {float(score):.1f} | {drivers_txt} | {blockers_txt} | {next_action or ''} | {link} |")
+        print()
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="ASEANForge Report Stub")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("matches", help="Emit a markdown brief of top matches")
+    m.add_argument("--since-days", type=int, default=1)
+    m.add_argument("--top", type=int, default=3)
+
+    args = ap.parse_args()
+    if args.cmd == "matches":
+        rc = cmd_matches(args.since_days, args.top)
+        sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/configs/vocab.yaml
+++ b/configs/vocab.yaml
@@ -1,0 +1,20 @@
+# Controlled vocabularies for Deal-Matching MVP
+# Note: Keep keys stable for importer validation; include common synonyms.
+
+technologies: [solar, wind, hydro, waste-to-energy, WtE, biomass, geothermal, battery, battery-storage, grid, mining, industrial_decarbonization]
+
+stages: [concept, feasibility, development, permits, construction, operational, term-sheet, financial-close]
+
+instruments: [equity, senior-debt, subordinated-debt, mezzanine, mezz, debt, guarantee, grant, insurance]
+
+offtake_status: [none, LOI, MOU, PPA-signed]
+
+esia_status: [none, scoping, draft, approved, final]
+
+ifc_categories: [A, B, C]
+
+themes: [climate-finance, gender-lens, China-plus-one, china_plus_one, energy-access, rural_access, grid_resilience, circular-economy, industrial_decarbonization]
+
+regions: [ASEAN, South Asia, East Asia, IDN, VNM, PHL, THA, MYS, SGP, KHM, LAO, MMR, BRN]
+
+countries_iso3: [IDN, THA, VNM, PHL, MYS, SGP, KHM, LAO, MMR, BRN]

--- a/configs/weights.yaml
+++ b/configs/weights.yaml
@@ -1,0 +1,9 @@
+# Weights for soft scoring components (sum to 1.0)
+# Components: mandate, readiness, commercials, risk, impact, strategic
+mandate: 0.25
+readiness: 0.20
+commercials: 0.20
+risk: 0.15
+impact: 0.10
+strategic: 0.10
+

--- a/data/templates/investors_template.csv
+++ b/data/templates/investors_template.csv
@@ -1,0 +1,5 @@
+name,type,mandate_regions,mandate_technologies,use_of_proceeds_allowed,instruments_offered,min_ticket_usd,max_ticket_usd,min_tenor_years,max_tenor_years,target_irr_range,risk_appetite,ifc_category_allowed,coal_exclusion,other_exclusions,lending_currencies,local_currency_pref,requires_site_visit,requires_ifc_ps,avg_decision_time_days,themes,notes,free_text
+Asian Development Bank,DFI,"{IDN,THA,VNM,PHL,MYS,SGP,KHM,LAO,MMR,BRN}","{solar,wind,hydro,battery,grid}","{capex,refi}","{debt,guarantee}",5000000,50000000,5,20,,low,"{A,B}",true,"{coal}","{USD,IDR,THB,VND,PHP,MYR,SGD}",true,false,true,120,"{grid_resilience,industrial_decarbonization}",,
+IFC,DFI,"{IDN,THA,VNM,PHL,MYS,SGP,KHM,LAO,MMR,BRN}","{solar,wind,hydro,biomass,WtE,geothermal,battery,grid}","{capex,refi}","{equity,debt,mezz}",10000000,200000000,5,15,,med,"{A,B,C}",true,,"{USD,IDR,THB,VND,PHP,MYR,SGD}",true,true,true,150,"{industrial_decarbonization}",,
+JBIC,ECA,"{IDN,THA,VNM,PHL,MYS}","{solar,wind,grid,mining}","{capex}","{debt,guarantee,insurance}",10000000,150000000,5,18,,med,"{A,B}",true,,"{USD,JPY}",false,false,false,180,"{grid_resilience}",,
+

--- a/data/templates/projects_template.csv
+++ b/data/templates/projects_template.csv
@@ -1,0 +1,4 @@
+sponsor_name,country_iso3,lat,lng,technology,capacity_value,capacity_unit,expected_cod,stage,capex_usd,ticket_open_usd,instrument_needed,currency,tenor_years,target_irr,offtake_status,permits_status,land_rights_status,grid_interconnect_status,esia_status,ifc_category,community_risk,pri_possible,eca_possible,sovereign_support,policy_alignment,china_plus_one_fit,nda_signed,data_room_url,free_text
+PT Nusantara Energy,IDN,-6.2,106.8,solar,50,MW,2027-06-30,feasibility,55000000,15000000,debt,USD,10,12,draft,draft,draft,none,scoping,B,med,true,true,false,"{RUPTL,grid_resilience}",true,false,https://example.com/dataroom,
+Thai Renew Co.,THA,13.7,100.5,wind,100,MW,2026-12-31,permits,120000000,30000000,mezz,THB,8,15,LOI,granted,secured,draft,final,B,low,true,false,true,"{grid_resilience}",false,true,https://example.com/wind-room,
+

--- a/infra/neon/migrations/002_matching.sql
+++ b/infra/neon/migrations/002_matching.sql
@@ -1,0 +1,104 @@
+-- Migration 002: Deal-Matching MVP tables (additive)
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Tables
+CREATE TABLE IF NOT EXISTS projects (
+  project_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sponsor_name     TEXT NOT NULL,
+  country_iso3     CHAR(3) NOT NULL,
+  lat              DOUBLE PRECISION,
+  lng              DOUBLE PRECISION,
+  technology       TEXT NOT NULL,
+  capacity_value   DOUBLE PRECISION,
+  capacity_unit    TEXT,
+  expected_cod     DATE,
+  stage            TEXT,
+  capex_usd        NUMERIC,
+  ticket_open_usd  NUMERIC,
+  instrument_needed TEXT,
+  currency         TEXT,
+  tenor_years      NUMERIC,
+  target_irr       NUMERIC,
+  offtake_status   TEXT,
+  permits_status   TEXT,
+  land_rights_status TEXT,
+  grid_interconnect_status TEXT,
+  esia_status      TEXT,
+  ifc_category     TEXT,
+  community_risk   TEXT,
+  pri_possible     BOOLEAN,
+  eca_possible     BOOLEAN,
+  sovereign_support BOOLEAN,
+  policy_alignment TEXT[],
+  china_plus_one_fit BOOLEAN,
+  nda_signed       BOOLEAN DEFAULT FALSE,
+  data_room_url    TEXT,
+  free_text        TEXT,
+  embedding        VECTOR(1536),
+  last_updated     TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS investors (
+  investor_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name               TEXT NOT NULL,
+  type               TEXT NOT NULL,
+  mandate_regions    TEXT[],
+  mandate_technologies TEXT[],
+  use_of_proceeds_allowed TEXT[],
+  instruments_offered TEXT[],
+  min_ticket_usd     NUMERIC,
+  max_ticket_usd     NUMERIC,
+  min_tenor_years    NUMERIC,
+  max_tenor_years    NUMERIC,
+  target_irr_range   TEXT,
+  risk_appetite      TEXT,
+  ifc_category_allowed TEXT[],
+  coal_exclusion     BOOLEAN,
+  other_exclusions   TEXT[],
+  lending_currencies TEXT[],
+  local_currency_pref BOOLEAN,
+  requires_site_visit BOOLEAN,
+  requires_ifc_ps    BOOLEAN,
+  avg_decision_time_days INTEGER,
+  themes             TEXT[],
+  contacts           JSONB,
+  notes              TEXT,
+  free_text          TEXT,
+  embedding          VECTOR(1536),
+  last_updated       TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS interactions (
+  interaction_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id     UUID REFERENCES projects(project_id) ON DELETE CASCADE,
+  investor_id    UUID REFERENCES investors(investor_id) ON DELETE CASCADE,
+  status         TEXT,
+  rating_by_investor SMALLINT,
+  rating_by_sponsor  SMALLINT,
+  reasons_declined   TEXT[],
+  notes          TEXT,
+  ts            TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+  match_id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID REFERENCES projects(project_id) ON DELETE CASCADE,
+  investor_id UUID REFERENCES investors(investor_id) ON DELETE CASCADE,
+  score_numeric NUMERIC NOT NULL,
+  drivers     TEXT[],
+  blockers    TEXT[],
+  next_action TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_projects_country_tech ON projects(country_iso3, technology);
+CREATE INDEX IF NOT EXISTS ix_investors_type ON investors(type);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_projects_nk ON projects(sponsor_name, country_iso3, technology, expected_cod);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_investors_name ON investors(name);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_matches_pair ON matches(project_id, investor_id);
+
+COMMIT;
+

--- a/infra/neon/schema.sql
+++ b/infra/neon/schema.sql
@@ -1,0 +1,113 @@
+-- ASEANForge Deal-Matching MVP Schema (additive)
+-- Safe, idempotent: creates extensions and new tables if missing
+
+BEGIN;
+
+-- Extensions (safe if already present)
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Projects seeking capital
+CREATE TABLE IF NOT EXISTS projects (
+  project_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sponsor_name     TEXT NOT NULL,
+  country_iso3     CHAR(3) NOT NULL,
+  lat              DOUBLE PRECISION,
+  lng              DOUBLE PRECISION,
+  technology       TEXT NOT NULL,
+  capacity_value   DOUBLE PRECISION,
+  capacity_unit    TEXT,
+  expected_cod     DATE,
+  stage            TEXT,
+  capex_usd        NUMERIC,
+  ticket_open_usd  NUMERIC,
+  instrument_needed TEXT,
+  currency         TEXT,
+  tenor_years      NUMERIC,
+  target_irr       NUMERIC,
+  offtake_status   TEXT,
+  permits_status   TEXT,
+  land_rights_status TEXT,
+  grid_interconnect_status TEXT,
+  esia_status      TEXT,
+  ifc_category     TEXT,
+  community_risk   TEXT,
+  pri_possible     BOOLEAN,
+  eca_possible     BOOLEAN,
+  sovereign_support BOOLEAN,
+  policy_alignment TEXT[],
+  china_plus_one_fit BOOLEAN,
+  nda_signed       BOOLEAN DEFAULT FALSE,
+  data_room_url    TEXT,
+  free_text        TEXT,
+  embedding        VECTOR(1536),
+  last_updated     TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Investors / funders
+CREATE TABLE IF NOT EXISTS investors (
+  investor_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name               TEXT NOT NULL,
+  type               TEXT NOT NULL,
+  mandate_regions    TEXT[],
+  mandate_technologies TEXT[],
+  use_of_proceeds_allowed TEXT[],
+  instruments_offered TEXT[],
+  min_ticket_usd     NUMERIC,
+  max_ticket_usd     NUMERIC,
+  min_tenor_years    NUMERIC,
+  max_tenor_years    NUMERIC,
+  target_irr_range   TEXT,
+  risk_appetite      TEXT,
+  ifc_category_allowed TEXT[],
+  coal_exclusion     BOOLEAN,
+  other_exclusions   TEXT[],
+  lending_currencies TEXT[],
+  local_currency_pref BOOLEAN,
+  requires_site_visit BOOLEAN,
+  requires_ifc_ps    BOOLEAN,
+  avg_decision_time_days INTEGER,
+  themes             TEXT[],
+  contacts           JSONB,
+  notes              TEXT,
+  free_text          TEXT,
+  embedding          VECTOR(1536),
+  last_updated       TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Interactions / feedback loop
+CREATE TABLE IF NOT EXISTS interactions (
+  interaction_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id     UUID REFERENCES projects(project_id) ON DELETE CASCADE,
+  investor_id    UUID REFERENCES investors(investor_id) ON DELETE CASCADE,
+  status         TEXT,
+  rating_by_investor SMALLINT,
+  rating_by_sponsor  SMALLINT,
+  reasons_declined   TEXT[],
+  notes          TEXT,
+  ts            TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Matches (idempotent via unique pair index)
+CREATE TABLE IF NOT EXISTS matches (
+  match_id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID REFERENCES projects(project_id) ON DELETE CASCADE,
+  investor_id UUID REFERENCES investors(investor_id) ON DELETE CASCADE,
+  score_numeric NUMERIC NOT NULL,
+  drivers     TEXT[],
+  blockers    TEXT[],
+  next_action TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS ix_projects_country_tech ON projects(country_iso3, technology);
+CREATE INDEX IF NOT EXISTS ix_investors_type ON investors(type);
+
+-- Natural key unique indexes for idempotent upserts
+CREATE UNIQUE INDEX IF NOT EXISTS ux_projects_nk ON projects(sponsor_name, country_iso3, technology, expected_cod);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_investors_name ON investors(name);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_matches_pair ON matches(project_id, investor_id);
+
+COMMIT;
+

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "=== Deal-Matching MVP Acceptance Test ==="
+
+# Step A: Load environment
+echo "[Step A] Loading environment from app/.env..."
+if [[ ! -f app/.env ]]; then
+  echo "  ✗ app/.env not found" >&2
+  exit 2
+fi
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ -z "$line" || "$line" =~ ^# ]] && continue
+  key="${line%%=*}"
+  val="${line#*=}"
+  export "${key}=${val}"
+done < app/.env
+echo "  NEON_DATABASE_URL: ${NEON_DATABASE_URL:+set}"
+echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:+set}"
+
+# Step B: Check database connectivity (with fallback for older libpq)
+echo "[Step B] Checking database connectivity..."
+set +e
+psql "$NEON_DATABASE_URL" -Atc "SELECT current_database() || '|' || current_user;"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  echo "  ✓ Connected successfully"
+else
+  echo "  ⚠ Initial connection failed; retrying without channel_binding=require (libpq <15 compatibility)"
+  NEON_NO_CB="${NEON_DATABASE_URL//&channel_binding=require/}"
+  NEON_NO_CB="${NEON_NO_CB//?channel_binding=require/}"
+  psql "$NEON_NO_CB" -Atc "SELECT current_database() || '|' || current_user;"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "  ✓ Connected with fallback URL (consider upgrading psql/libpq to 16+)"
+    export NEON_DATABASE_URL="$NEON_NO_CB"
+  else
+    echo "  ✗ Database connection failed even with fallback"
+    exit 1
+  fi
+fi
+set -e
+
+# Step C: Apply schema (idempotent)
+echo "[Step C] Applying database schema..."
+psql "$NEON_DATABASE_URL" -f infra/neon/schema.sql
+
+# Step D: Ensure sample data files exist
+echo "[Step D] Checking sample data files..."
+mkdir -p data/samples
+if [ ! -f data/samples/projects.csv ] || [ $(wc -l < data/samples/projects.csv) -lt 2 ]; then
+  echo "  ⚠ data/samples/projects.csv missing or empty; using template"
+  cp -f data/templates/projects_template.csv data/samples/projects.csv
+fi
+if [ ! -f data/samples/investors.csv ] || [ $(wc -l < data/samples/investors.csv) -lt 2 ]; then
+  echo "  ⚠ data/samples/investors.csv missing or empty; using template"
+  cp -f data/templates/investors_template.csv data/samples/investors.csv
+fi
+
+# Step E: Import data (idempotent UPSERTs)
+echo "[Step E] Importing projects and investors..."
+.venv/bin/python app/importer.py projects --csv=data/samples/projects.csv
+.venv/bin/python app/importer.py investors --csv=data/samples/investors.csv
+
+# Step F: Run batch matching
+echo "[Step F] Running batch matcher..."
+.venv/bin/python app/matcher.py batch --min-score=1 --top=5
+
+# Step G: Generate report
+echo "[Step G] Generating match report..."
+.venv/bin/python app/report_stub.py matches --since-days=7 --top=3
+
+echo ""
+echo "=== Acceptance Test Complete ==="
+

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mask() {
+  local s="$1"; local n=${#s}
+  if (( n <= 8 )); then echo "****"; else echo "${s:0:8}****"; fi
+}
+
+# Load from app/.env if present (safely; support special chars like '&')
+if [[ -f "app/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . app/.env
+  set +a
+fi
+
+# Check NEON_DATABASE_URL
+if [[ -z "${NEON_DATABASE_URL:-}" ]]; then
+  echo "ERROR: NEON_DATABASE_URL not set. Ensure app/.env contains NEON_DATABASE_URL." >&2
+  exit 2
+fi
+# Normalize quotes around URL for connectivity tests
+if [[ -n "${NEON_DATABASE_URL:-}" ]]; then
+  if [[ ${NEON_DATABASE_URL} == "'"*"'" ]]; then
+    NEON_DATABASE_URL=${NEON_DATABASE_URL:1:${#NEON_DATABASE_URL}-2}
+  elif [[ ${NEON_DATABASE_URL} == '"'*'"' ]]; then
+    NEON_DATABASE_URL=${NEON_DATABASE_URL:1:${#NEON_DATABASE_URL}-2}
+  fi
+fi
+
+if [[ "$NEON_DATABASE_URL" != postgresql://* ]]; then
+  echo "ERROR: NEON_DATABASE_URL must start with 'postgresql://'. Current: '$NEON_DATABASE_URL'" >&2
+  echo "Hint: Do not include quotes and do not use '+psycopg' suffix." >&2
+  exit 2
+fi
+
+# Print masked
+echo "NEON_DATABASE_URL: ok (postgresql://...)"
+
+# psql connectivity
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not found in PATH" >&2
+  exit 2
+fi
+
+set +e
+psql "$NEON_DATABASE_URL" -c '\\conninfo' >/dev/null 2>&1
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  # Fallback: strip channel_binding=require which may be unsupported in some local libpq builds
+  ALT_URL="$NEON_DATABASE_URL"
+  ALT_URL="${ALT_URL//&channel_binding=require/}"
+  ALT_URL="${ALT_URL//?channel_binding=require/}"
+  if [[ "$ALT_URL" != "$NEON_DATABASE_URL" ]]; then
+    psql "$ALT_URL" -c '\\conninfo' >/dev/null 2>&1
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+      set -e
+      echo "psql connectivity: ok (fallback without channel_binding)"
+    else
+      set -e
+      echo "ERROR: Failed to connect to Neon via psql. Check sslmode and credentials." >&2
+      echo "Hint: URL should look like postgresql://user:pass@host/db?sslmode=require" >&2
+      exit 3
+    fi
+  else
+    set -e
+    echo "ERROR: Failed to connect to Neon via psql. Check sslmode and credentials." >&2
+    echo "Hint: URL should look like postgresql://user:pass@host/db?sslmode=require" >&2
+    exit 3
+  fi
+else
+  set -e
+  echo "psql connectivity: ok"
+fi
+
+# OPENAI key
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "OPENAI_API_KEY: not set (importer will skip embeddings)"
+else
+  echo "OPENAI_API_KEY: $(mask "$OPENAI_API_KEY")"
+fi
+
+echo "Environment check complete."
+

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Load app/.env safely (handles special chars like '&' in URLs)
+if [[ ! -f app/.env ]]; then
+  echo "ERROR: app/.env not found" >&2
+  exit 2
+fi
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ -z "$line" || "$line" =~ ^# ]] && continue
+  key="${line%%=*}"
+  val="${line#*=}"
+  export "${key}=${val}"
+done < app/.env
+echo "NEON_DATABASE_URL set: ${NEON_DATABASE_URL:+yes}"
+echo "OPENAI_API_KEY set: ${OPENAI_API_KEY:+yes}"
+


### PR DESCRIPTION
This PR makes the Deal‑Matching MVP operational end‑to‑end with a single command.

What’s included
- scripts/acceptance.sh: One‑command acceptance runner (Steps A–G)
  - Hardened DB connectivity check via SQL probe + channel_binding=require fallback
  - Applies schema, ensures sample CSVs from templates, imports, matches, and prints report
- scripts/env.sh: Safe .env loader (line‑by‑line; no eval), works in bash/zsh
- app/importer.py: Fix parse_list to split on pipes when present, else commas
  - Prevents mandate arrays from being parsed as a single string; enables hard filters to pass
  - JSON metrics output (rows_read, upserts, errors, skipped)
- app/matcher.py / app/report_stub.py: Robust dotenv load: Path(__file__).parent/".env"
- configs: Add vocab.yaml and weights.yaml for scoring + validation
- infra/neon: schema.sql (tables, indexes, unique constraints) and migration file
- data/templates: CSV templates for projects and investors

Why
- Resolve environment parsing issues with special chars (e.g., & in DB URL)
- Make acceptance test idempotent and zero‑manual‑steps
- Ensure hard filters and scoring produce matches with provided sample data

Verification
- Ran `bash scripts/acceptance.sh` locally:
  - DB: `neondb|neondb_owner` reported; fallback not required
  - Importers: {"rows_read": 3, "upserts": 3, "errors": 0} and {"rows_read": 4, "upserts": 4, "errors": 0}
  - Matcher: {"projects": 3, "total_matches": 2, "min_score": 1.0, "top": 5}
  - Report: Markdown table printed two Solar Siam matches

Notes
- app/.env is not committed; scripts expect it to exist locally
- Re-runnable: schema/table/index creation is IF NOT EXISTS; UPSERTs maintain idempotency

Please review and merge into release/v1.4. Thanks!

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author